### PR TITLE
fix: replace binary verdict with Low/Medium/High threat severity in scan_logs

### DIFF
--- a/api/cmd/types.go
+++ b/api/cmd/types.go
@@ -62,10 +62,27 @@ func forwardToMLService(data AnalysisRequest) (*AnalysisResponse, error) {
     }
 
     // 3. Translate Python Response -> Go Expected Struct for Database Logging
+    //
+    // Threat level is derived from the model's phishing probability score,
+    // independent of the binary Verdict label:
+    //   < 0.40  → "Low"    (likely legitimate, negligible risk)
+    //   < 0.70  → "Medium" (suspicious, warrants caution)
+    //   >= 0.70 → "High"   (high-confidence phishing, block triggered)
+    threatLevel := func(p float64) string {
+        switch {
+        case p >= 0.70:
+            return "High"
+        case p >= 0.40:
+            return "Medium"
+        default:
+            return "Low"
+        }
+    }(pyResp.PhishingProbability)
+
     result := AnalysisResponse{
         IsSpoof:         pyResp.Verdict == "Phishing",
         ConfidenceScore: pyResp.PhishingProbability,
-        ThreatLevel:     pyResp.Verdict, 
+        ThreatLevel:     threatLevel,
     }
 
     return &result, nil


### PR DESCRIPTION
## Summary
Fixes #<issue-number>

Resolves the mismatch between `threat_level` and `is_spoof` in the `scan_logs` 
table. Previously both columns were effectively encoding the same binary signal. 
`threat_level` now carries independent severity information derived from the 
model's raw probability output.

## Changes
- `api/cmd/types.go` — replaced `ThreatLevel: pyResp.Verdict` with an inline 
  classifier that maps `PhishingProbability` to `"Low"` / `"Medium"` / `"High"`

## Behaviour After This PR

| phishing_probability | threat_level | is_spoof |
|---|---|---|
| < 0.40 | Low | false |
| 0.40 – 0.69 | Medium | false |
| ≥ 0.70 | High | true |

Note: `threat_level` and `is_spoof` are derived independently. A scan can 
return `is_spoof: false` with `threat_level: Medium` for borderline pages — 
this is intentional and allows the dashboard to surface yellow warnings without 
triggering the full blocking overlay.

